### PR TITLE
Create vector index with custom dimension

### DIFF
--- a/citrusdb/api/index.py
+++ b/citrusdb/api/index.py
@@ -1,6 +1,6 @@
 import os
 import pickle
-from typing import Any, List, Optional
+from typing import List, Optional
 from numpy import float32
 from numpy._typing import NDArray
 from citrusdb.db.index.hnswlib import HnswIndex
@@ -20,8 +20,9 @@ class Index:
         M: int = 64,
         ef_construction: int = 200,
         allow_replace_deleted: bool = False,
+        dimension: int = 1536
     ):
-        self._db = HnswIndex(id=name)
+        self._db = HnswIndex(id=name, dim=dimension)
 
         self._parameters = {
             "index_name": name,

--- a/citrusdb/api/local.py
+++ b/citrusdb/api/local.py
@@ -40,6 +40,7 @@ class LocalAPI:
     def create_index(
         self,
         name: str,
+        dimension: int = 1536,
         max_elements: int = 1000,
         M: int = 64,
         ef_construction: int = 200,
@@ -51,7 +52,8 @@ class LocalAPI:
                 max_elements,
                 M,
                 ef_construction,
-                allow_replace_deleted
+                allow_replace_deleted,
+                dimensions=dimension
             )
 
         self._db[name] = Index(
@@ -60,7 +62,8 @@ class LocalAPI:
             persist_directory=self.persist_directory,
             M=M,
             ef_construction=ef_construction,
-            allow_replace_deleted=allow_replace_deleted
+            allow_replace_deleted=allow_replace_deleted,
+            dimension=dimension
         )
 
     def add(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "citrusdb"
-version = "0.6.0"
+version = "0.6.1"
 
 authors = [
   { name="Debabrata Mondal", email="debabrata.js@protonmail.com" },
 ]
-description = "open-source vector database. store and retrieve embeddings for your next project!"
+description = "open-source vector database. store and retrieve embeddings for your next ai project!"
 readme = "README.md"
 requires-python = ">=3.7"
 classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="citrusdb",
-    version="0.6.0",
+    version="0.6.1",
     author="Debabrata Mondal",
     author_email="debabrata.js@protonmail.com",
     description="(distributed) vector database",


### PR DESCRIPTION
# Description

Allow users to create indices with custom dimension.
This will allow users to use citrus with embedding models other than OpenAI's `text-embedding-ada-002`.
By default, vector indices will be created with `1536` dimension for backwards compatibility.

# Closes #5 